### PR TITLE
Feature package update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 .idea
+.nyc_output

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,18 @@
+{
+    "check-coverage": false,
+    "per-file": true,
+    "exclude": [
+        "coverage/**/*.js",
+        "config/*.js",
+        "test/**/*.js",
+        "index.js"
+    ],
+    "reporter": [
+        "html",
+        "text",
+        "text-summary"
+    ],
+    "cache": true,
+    "all": true,
+    "report-dir": "./coverage"
+}

--- a/package.json
+++ b/package.json
@@ -35,17 +35,17 @@
     "manager"
   ],
   "dependencies": {
-    "debug": "2.6.1",
-    "js-yaml": "3.8.1"
+    "debug": "3.1.0",
+    "js-yaml": "3.10.0"
   },
   "devDependencies": {
-    "coveralls": "2.11.16",
-    "chai": "3.5.0",
-    "mocha": "3.2.0",
-    "mocha-lcov-reporter": "1.2.0",
+    "coveralls": "3.0.0",
+    "chai": "4.1.2",
+    "mocha": "4.0.1",
+    "mocha-lcov-reporter": "1.3.0",
     "istanbul": "0.4.5",
-    "jshint": "2.9.4",
-    "rewire": "2.5.2"
+    "jshint": "2.9.5",
+    "rewire": "3.0.2"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   ],
   "scripts": {
     "pretest": "./node_modules/jshint/bin/jshint .",
-    "test": "NODE_ENV='test' ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha test",
-    "test-on-travis": "NODE_ENV='test' ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "test": "NODE_ENV='test' ./node_modules/.bin/nyc ./node_modules/.bin/_mocha test",
+    "test-on-travis": "NODE_ENV='test' ./node_modules/.bin/nyc ./node_modules/.bin/_mocha test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "main": "index.js",
   "repository": {
@@ -43,7 +43,7 @@
     "chai": "4.1.2",
     "mocha": "4.0.1",
     "mocha-lcov-reporter": "1.3.0",
-    "istanbul": "0.4.5",
+    "nyc": "11.3.0",
     "jshint": "2.9.5",
     "rewire": "3.0.2"
   },


### PR DESCRIPTION
Fix _debug_ vunerability: https://nodesecurity.io/advisories/534
Update dependencies
Migrate outdated istanbul to nyc

Travis test failed because of its node version v0.10.48.
Is it possible to upgrade it to a more recent one ?